### PR TITLE
Add application submission endpoint and client integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+applications.json
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
+    "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const fs = require('fs').promises;
+const path = require('path');
+
+const app = express();
+app.use(express.json());
+
+const dataFile = path.join(__dirname, 'applications.json');
+
+app.post('/api/applications', async (req, res) => {
+  const submission = { ...req.body, submittedAt: new Date().toISOString() };
+  let existing = [];
+  try {
+    const content = await fs.readFile(dataFile, 'utf8');
+    existing = JSON.parse(content);
+  } catch (err) {
+    // file might not exist yet
+  }
+  existing.push(submission);
+  await fs.writeFile(dataFile, JSON.stringify(existing, null, 2));
+  res.status(201).json({ success: true });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on ${PORT}`);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -109,10 +109,24 @@ function ApplyNowForm({ onBackHome }) {
     setForm({ ...form, [steps[step].name]: value });
   };
 
-  const handleNext = (e) => {
+  const handleNext = async (e) => {
     e.preventDefault();
-    if (step < steps.length - 1) setStep(step + 1);
-    else setSubmitted(true);
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      try {
+        await fetch("/api/applications", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(form),
+        });
+      } catch (err) {
+        console.error("Failed to submit application", err);
+      }
+      setSubmitted(true);
+    }
   };
   const handlePrev = () => (step > 0 ? setStep(step - 1) : onBackHome());
 


### PR DESCRIPTION
## Summary
- Post application data to `/api/applications` from the final form step
- Add Express server endpoint to record applications to a JSON file
- Configure Express dependency and start script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b60cf41fa083319a0153f251134254